### PR TITLE
Add URL to package header

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -5,6 +5,7 @@
 ;; Author: Yann Hodique <yann.hodique@gmail.com>
 ;; Keywords: tools
 ;; Version: 0.4
+;; URL: https://github.com/sigma/magit-gh-pulls
 ;; Package-Requires: ((emacs "24") (gh "0.4.3") (magit "1.1.0") (pcache "0.2.3") (s "1.6.1"))
 
 ;; This file is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Let's users browse the Github page from `M-x list-package` in Emacs 24.4.

By the way, the copyright line seems to be quite outdated ;)
