### PR TITLE
Don't try to match SSH username

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -65,8 +65,8 @@
   (let ((url (magit-get "remote" "origin" "url")))
     (when url
       (let ((creds (cond
-                    ((s-matches? "^git@github.com" url)
-                     (s-match "^git@github.com:\\(.+\\)/\\([^.]+\\)\\(.git\\)$" url))
+                    ((s-matches? "github.com:" url)
+                     (s-match "github.com:\\(.+\\)/\\([^.]+\\)\\(.git\\)$" url))
 
                     ((s-matches? "^https?://github.com" url)
                      (s-match "^https://github.com/\\(.+\\)/\\([^/]+\\)/?$" url)))))


### PR DESCRIPTION
Makes this extension work in cases where the username is set in `.ssh/config`.  It's redundant anyway, since there's no other username by which one could connect to Github via SSH.
