### PR TITLE
Add in support for "git://" urls.

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -72,7 +72,9 @@
                  (s-match "github.com:\\(.+\\)/\\([^.]+\\)\\(.git\\)?$" url))
 
                 ((s-matches? "^https?://github.com" url)
-                 (s-match "^https://github.com/\\(.+\\)/\\([^./]+\\)\\(.git\\)?/?$" url)))))
+                 (s-match "^https://github.com/\\(.+\\)/\\([^./]+\\)\\(.git\\)?/?$" url))
+                ((s-matches? "git://github.com/" url)
+                 (s-match "git://github.com/\\(.+\\)/\\([^.]+\\)\\(.git\\)?$" url)))))
     (when creds
       (cons (cadr creds) (caddr creds)))))
 


### PR DESCRIPTION
Composer seems to create repos using the git: protocol, which magit-gh-pulls didn't understand. So I added it.
