### PR TITLE
Make parse-url handle repo names containing .

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -78,12 +78,11 @@
 (defun magit-gh-pulls-parse-url (url)
   (let ((creds (cond
                 ((s-matches? "github.com:" url)
-                 (s-match "github.com:\\(.+\\)/\\([^.]+\\)\\(.git\\)?$" url))
-
+                 (s-match "github.com:\\(.+\\)/\\(.+\\)\\(.git\\)?$" url))
                 ((s-matches? "^https?://github.com" url)
-                 (s-match "^https://github.com/\\(.+\\)/\\([^./]+\\)\\(.git\\)?/?$" url))
+                 (s-match "^https://github.com/\\(.+\\)/\\([^/]+\\)\\(.git\\)?/?$" url))
                 ((s-matches? "git://github.com/" url)
-                 (s-match "git://github.com/\\(.+\\)/\\([^.]+\\)\\(.git\\)?$" url)))))
+                 (s-match "git://github.com/\\(.+\\)/\\(.+\\)\\(.git\\)?$" url)))))
     (when creds
       (cons (cadr creds) (caddr creds)))))
 


### PR DESCRIPTION
this happend to me when trying to look at a PR for `edn.el`.