### PR TITLE
Don't assume that Host is set in ssh/config

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -156,7 +156,7 @@
          (parsed-url (url-generic-parse-url fixed-url))
          (ssh-host (when (string= (url-type parsed-url) "ssh")
                      (assoc (url-host parsed-url) ssh-config-hosts))))
-    (when ssh-host
+    (when (and ssh-host (cadr ssh-host))
       (setf (url-host parsed-url) (cadr ssh-host)))
     (when (and
            (string= (url-host parsed-url) "github.com")


### PR DESCRIPTION
SSH does not require "Hostname" to be set, in which case the "Host" line denotes the Hostname, as in:

```
Host github.com
  Compression yes
  User git
  IdentityFile %d/.ssh/github
```

`magit-gh-pulls-get-ssh-config-hosts` does not set the `cadr` of the parsed host name cell in this case, and consequently `magit-gh-pulls-parse-url` failed to get the correct hostname in this case.

Now we check whether the host name is actually configured, and only update the host name if it's there.

Fixes auto-detection of the Github repo for people with entries such as above in their `.ssh/config` (e.g. myself :relaxed:)