### PR TITLE
Check out PR branches rather than leaving them dangling

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -282,7 +282,7 @@
                    "Branch base: "
                    (oref (oref req :base) :ref)))
             (inhibit-magit-refresh t))
-       (magit-branch branch base)
+       (magit-branch-and-checkout branch base)
        (magit-merge (oref (oref req :head) :sha)))
      (magit-refresh))
     (unfetched-pull
@@ -298,7 +298,7 @@
             (branch (magit-gh-pulls-guess-topic-name req))
             (base (oref (oref req :base) :ref))
             (inhibit-magit-refresh t))
-       (magit-branch branch base)
+       (magit-branch-and-checkout branch base)
        (magit-merge (oref (oref req :head) :sha))
        (magit-checkout base)
        (magit-merge branch)


### PR DESCRIPTION
Currently, `magit-gh-pulls-create-branch` and
`magit-gh-pulls-merge-pull-request` don't behave as described in the
README, since they create new branches (without checking them out) and
then proceed to merge things into whatever branch or ref you currently
have checked out.  The newly created branch just sits there at the base.
Fix this by using the appropriate magit API to both create *and*
checkout a new branch.