### PR TITLE
Stop using magit-get-remote-branch

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -374,8 +374,7 @@ option, or inferred from remotes."
     remote-head))
 
 (defun magit-gh-pulls-build-req (user proj)
-  (let* ((current (or (cdr (magit-get-remote-branch))
-                      (magit-get-current-branch)))
+  (let* ((current (magit-get-current-branch))
          (current-default (magit-gh-pulls-get-remote-default))
          (base-branch (magit-read-other-branch-or-commit "Base" nil current-default))
          (head-branch (magit-read-other-branch-or-commit "Head" nil current)))


### PR DESCRIPTION
It was removed from Magit v2.4.  Instead just use the value of
`magit-get-current-branch`, which already was the fallback before.

This should be the right branch most of the time and if it is not, then
that isn't a huge problem because it is only used as the default choice
when later reading the "Head" branch from the user.

Also now that Magit supports the "push-remote", starting with v2.4, the
name of the branch one pushes to, almost always is identical to the
local name anyway.