### PR TITLE
Fix reversed application of collapse-commits

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -78,7 +78,7 @@
   viewed in magit. It receives a list of pull requests and should
   return a list of pull requests.")
 
-(defvar magit-gh-pulls-collapse-commits nil
+(defvar magit-gh-pulls-collapse-commits t
   "Collapse commits in pull requests listing.")
 
 (defun magit-gh-pulls-get-api ()
@@ -243,7 +243,7 @@ option, or inferred from remotes."
                       (cond
                        (have-commits
                         (magit-insert-section
-                          (pull info (not magit-gh-pulls-collapse-commits))
+                          (pull info magit-gh-pulls-collapse-commits)
                           (insert heading)
                           (magit-insert-heading)
                           (when (and have-commits (not applied))


### PR DESCRIPTION
The third param as part of that `magit-insert-section` macro determines whether the section should be hidden. If `collapse-commits` is true, that param should also be true, not the other way around. To preserve default behavior for users who had not overridden the variable, the default value is also switched.