### PR TITLE
Display mergable state in PR header

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -253,7 +253,7 @@ option, or inferred from remotes."
                                          (magit-git-string "branch" branch
                                                            (format "--contains=%s" head-sha))))
                            (heading
-                            (format "[%s@%s] %s\n"
+                            (format "[%s@%s] %s %s\n"
                                     (propertize (number-to-string id)
                                                 'face 'magit-tag)
                                     (if (string= base-ref branch)
@@ -265,7 +265,10 @@ option, or inferred from remotes."
                                      (cond (applied 'magit-cherry-equivalent)
                                            (have-commits nil)
                                            (invalid 'error)
-                                           (t 'italic)))))
+                                           (t 'italic)))
+                                    (propertize
+                                     "●" 'face
+                                     (if (oref req :mergeable) 'success 'error))))
                            (info (list user proj id)))
                       (cond
                        (have-commits


### PR DESCRIPTION
This adds a small visual indicator to the PR header showing whether the branch can be merged without conflicts using the :mergeable value in the response. Feedback welcome.