### PR TITLE
Use cl-lib for cl functions

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -63,6 +63,7 @@
 (require 'gh-pulls)
 (require 'pcache)
 (require 's)
+(require 'cl-lib)
 
 (defgroup magit-gh-pulls nil
   "Github.com pull-requests for Magit."
@@ -239,7 +240,7 @@ option, or inferred from remotes."
                 (magit-insert-section (pulls)
                   (magit-insert-heading "Pull Requests:")
                   (dolist (stub stubs)
-                    (incf i)
+                    (cl-incf i)
                     (let* ((id (oref stub :number))
                            (base-sha (oref (oref stub :base) :sha))
                            (base-ref (oref (oref stub :base) :ref))


### PR DESCRIPTION
For some reason, the MELPA installed version didn't work for me because of
the cl functions not being namespaced. I switched the few cl function calls
to use the namespaced versions, and made the dependency on cl-lib explicit.