### PR TITLE
Stop excluding branches when creating PRs

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -410,8 +410,8 @@ option, or inferred from remotes."
    editor which is responsible for continuing the flow."
   (let* ((current (magit-get-current-branch))
          (current-default (magit-gh-pulls-get-remote-default))
-         (base-branch (magit-read-other-branch-or-commit "Base" nil current-default))
-         (head-branch (magit-read-other-branch-or-commit "Head" nil current)))
+         (base-branch (magit-read-branch-or-commit "Base" current-default))
+         (head-branch (magit-read-branch-or-commit "Head" current)))
     (let* ((head-remote (concat (magit-get-remote base-branch) "/" head-branch))
            (pushed-p (and (magit-branch-p head-remote)
                           (null (magit-git-lines "diff" (concat head-remote ".." head-branch))))))


### PR DESCRIPTION
Maybe I've misunderstood how this is supposed to work, but I found it weird that it wasn't possible to select the currently checked out branch as either base or head when creating a PR.

I'm fairly confident that I'm missing something here, but if I try to create a PR for a branch `foo` while having it checked out, it wasn't available in the list of branches. If I choose `origin/foo` from the same list, it just says that the branch isn't pushed.