### PR TITLE
Add Github Pull Request entry in magit-dispatch-popup.

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -582,11 +582,16 @@ option, or inferred from remotes."
   (or (derived-mode-p 'magit-mode)
       (error "This mode only makes sense with magit"))
   (if magit-gh-pulls-mode
-      (magit-add-section-hook
-       'magit-status-sections-hook
-       'magit-gh-pulls-insert-gh-pulls
-       'magit-insert-stashes)
-    (remove-hook 'magit-status-sections-hook 'magit-gh-pulls-insert-gh-pulls))
+      (progn
+        (magit-add-section-hook
+         'magit-status-sections-hook
+         'magit-gh-pulls-insert-gh-pulls
+         'magit-insert-stashes)
+        (magit-define-popup-action 'magit-dispatch-popup
+          ?# "Github PR" 'magit-gh-pulls-popup ?!))
+    (progn
+      (remove-hook 'magit-status-sections-hook 'magit-gh-pulls-insert-gh-pulls)
+      (magit-remove-popup-key 'magit-dispatch-popup :action ?#)))
   (when (called-interactively-p 'any)
     (magit-refresh)))
 


### PR DESCRIPTION
This patch permit to add an entry in `magit-dispatch-popup` see bellow :

```
Popup and dwim commands
 A Cherry-picking          b Branching               B Bisecting               c Committing
 d Diffing                 D Change diffs            e Ediff dwimming          E Ediffing
 f Fetching                F Pulling                 l Logging                 L Change logs
 m Merging                 M Remoting                o Submodules              O Subtrees
 P Pushing                 r Rebasing                t Tagging                 T Notes
 V Reverting               w Apply patches           W Format patches          X Resetting
 y Show Refs               z Stashing                ! Running                 # Github PR
```
