### PR TITLE
Extract all hosts aliases from ssh config

### DIFF
--- a/magit-gh-pulls-tests.el
+++ b/magit-gh-pulls-tests.el
@@ -13,9 +13,12 @@
   (let* ((sample-input '("Host one" "extraneous" "\tHostname one.other.com" "\t\tUser doesntmatter" "HostName two.other.com"))
          (sample-data (-magit-gh-pulls-filter-and-split-host-lines sample-input))
          (more-input '("Sir not appearing in this picture" "Host two" "IdentityFile ~/.ssh/HostName" "\tUser Host" "HostName two.host.com"))
-         (bigger-sample (-magit-gh-pulls-filter-and-split-host-lines (append sample-input more-input))))
+         (bigger-sample (-magit-gh-pulls-filter-and-split-host-lines (append sample-input more-input)))
+         (multialias-input '("Host one two" "extraneous" "\tHostname one.other.com" "\t\tUser doesntmatter" "HostName two.other.com"))
+         (multialias-data (-magit-gh-pulls-filter-and-split-host-lines multialias-input)))
     (should (equal (magit-gh-pulls-get-host-hostnames sample-data) '(("one" . ("two.other.com" "one.other.com")))))
-    (should (equal (magit-gh-pulls-get-host-hostnames bigger-sample) '(("two" . ("two.host.com")) ("one" . ("two.other.com" "one.other.com")))))))
+    (should (equal (magit-gh-pulls-get-host-hostnames bigger-sample) '(("two" . ("two.host.com")) ("one" . ("two.other.com" "one.other.com")))))
+    (should (equal (magit-gh-pulls-get-host-hostnames multialias-data) '(("two" . ("two.other.com" "one.other.com")) ("one" . ("two.other.com" "one.other.com")))))))
 
 (ert-deftest magit-gh-pulls-parse-url-test ()
   ;;Mock config hosts

--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -146,7 +146,7 @@ config option."
         (rest-lines (cdr config-lines)))
     (while rest-lines
       (if (string= (cadr curline) "Host")
-          (let ((hosts (s-split "\\s*" (cadr (cdr curline)))) ;;List of the host aliases
+          (let ((hosts (s-split "\s+" (cadr (cdr curline)))) ;;List of the host aliases
                 (rest-result (magit-gh-pulls-collect-hostnames rest-lines)))
             (dolist (host hosts)
               ;;Host must be lowercase because the url parser lowercases the string


### PR DESCRIPTION
In SSH config it is possible to specify multiple host aliases for
a single host. This updates the `magit-gh-pulls-get-host-hostnames`
to transform the following config:

```
Host alias1 alias2
  HostName name1
  HostName name2
```

into a list:

`((alias1 . (name1 name2) (alias2 . (name1 name2))))`