### PR TITLE
correctly handle remotes without a URL

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -208,11 +208,12 @@ config option."
   (let ((creds nil)
         (ssh-config-hosts (magit-gh-pulls-get-ssh-config-hosts)))
     (dolist (remote (magit-git-lines "remote") creds)
-      (let ((parsed (magit-gh-pulls-parse-url
-                     (magit-get "remote" remote "url")
-                     ssh-config-hosts)))
-        (when parsed
-          (setq creds parsed))))))
+      (let ((url (magit-get "remote" remote "url")))
+        (if url
+          (let ((parsed (magit-gh-pulls-parse-url url ssh-config-hosts)))
+            (when parsed
+              (setq creds parsed)))
+          (message "Warning: no URL for remote %s" remote))))))
 
 (defun magit-gh-pulls-guess-repo ()
   "Return (user . project) pair obtained either from explicit


### PR DESCRIPTION
Remotes can exist without a URL, for valid reasons.  For example, when using git-annex, the Glacier special remote does not require a URL:

- http://git-annex.branchable.com/tips/using_Amazon_Glacier/

So avoid calling magit-gh-pulls-parse-url unless we actually have a URL to parse.