### PR TITLE
Assume lowercase file name for PR template file

### DIFF
--- a/magit-gh-pulls.el
+++ b/magit-gh-pulls.el
@@ -457,9 +457,20 @@ option, or inferred from remotes."
   current repository. Returns nil if there is not a pull request
   template file. A pull request template file can be placed in
   the repository root directory, or in a .github/ directory."
-  (car (or (directory-files (magit-toplevel) t "^PULL_REQUEST_TEMPLATE")
+  (car (or (directory-files (magit-toplevel) t "^pull_request_template")
            (ignore-errors (directory-files (format "%s.github/" (magit-toplevel))
-                                           t "^PULL_REQUEST_TEMPLATE")))))
+                                           t "^pull_request_template"))
+           (ignore-errors (directory-files (format "%sdocs/" (magit-toplevel))
+                                           t "^pull_request_template"))
+           (ignore-errors (directory-files
+                           (format "%sPULL_REQUEST_TEMPLATE/" (magit-toplevel))
+                           t "^pull_request_template"))
+           (ignore-errors (directory-files
+                           (format "%s.github/PULL_REQUEST_TEMPLATE/" (magit-toplevel))
+                           t "^pull_request_template"))
+           (ignore-errors (directory-files
+                           (format "%sdocs/PULL_REQUEST_TEMPLATE/" (magit-toplevel))
+                           t "^pull_request_template")))))
 
 (defun magit-gh-pulls-init-pull-editor (proj base head callback)
   "Create a new buffer for editing this pull request and switch


### PR DESCRIPTION
This also includes support for the PULL_REQUEST_TEMPLATE subdirectory
supported by Github. See
https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository.

This is my first time contributing to any sort of elisp project, let me know what I can do to make this process better/easier!

The main thing I was trying to fix here is that the current upcased `PULL_REQUEST_TEMPLATE` doesn't match the downcased `pull_request_template.md` used by my organization. I dug into [Github's docs](https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository) and it looks like the template can be in a few different places that were not yet supported by magit-gh-pulls.

This PR changes the case on the expected file to the lowercase that Github suggests, and adds in the other places where this file could be found. It does _not_ add support for multiple templates.